### PR TITLE
qa: Ignore mypy warnings in `requests_mocker.Mock`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,9 @@ skip = [
     "docs/conf.py",
 ]
 
+
 [tool.mypy]
+ignore_missing_imports = true
 show_error_codes = true
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ skip = [
 [tool.mypy]
 ignore_missing_imports = true
 show_error_codes = true
+warn_unused_ignores = true
 
 
 [tool.pylint.MASTER]

--- a/src/cogite/plugins.py
+++ b/src/cogite/plugins.py
@@ -5,7 +5,7 @@ try:
     import importlib.metadata as importlib_metadata
 except ImportError:
     # Python < 3.8
-    import importlib_metadata  # type: ignore
+    import importlib_metadata  # type: ignore[no-redef]
 
 
 NAMESPACE_CI_URL_GETTER = 'cogite.plugins.ci_url_getter'

--- a/src/cogite/spinner.py
+++ b/src/cogite/spinner.py
@@ -1,4 +1,4 @@
-import yaspin  # type: ignore
+import yaspin
 
 from cogite import interaction
 

--- a/src/cogite/version.py
+++ b/src/cogite/version.py
@@ -2,6 +2,6 @@ try:
     from importlib import metadata
 except ImportError:
     # Python<3.8: use importlib-metadata package
-    import importlib_metadata as metadata  # type: ignore
+    import importlib_metadata as metadata  # type: ignore[no-redef]
 
 VERSION = metadata.version('cogite')

--- a/tests/requests_mocker.py
+++ b/tests/requests_mocker.py
@@ -84,8 +84,8 @@ class Mock():
         call = Call(
             request=Request(
                 url=url,
-                data=request.data or b'',
-                headers=request.headers,
+                data=request.data or b'',  # type: ignore[arg-type]
+                headers=request.headers,  # type: ignore[arg-type]
             ),
             response=response,
         )


### PR DESCRIPTION
Warnings are not really relevant:

    Argument "data" to "Request" has incompatible type "Union[bytes, SupportsRead[bytes], Iterable[bytes]]"; expected "bytes"
    Argument "headers" to "Request" has incompatible type "MutableMapping[str, str]"; expected "Dict[str, str]"


qa: Globally ignore mypy warnings about missing imports


qa: Qualify mypy "ignore" comments


qa: Warn about mypy unused "ignore" comments